### PR TITLE
[PRO-845] correct relative path handling

### DIFF
--- a/config/commands/defaults.sh
+++ b/config/commands/defaults.sh
@@ -68,16 +68,17 @@ open() {
     fi
 
     if [[ $1 == /* ]]; then
-        # Absolute path: Check if file is in REPO_ROOT
+        # Absolute path
         FULL_PATH=$1
-        if [[ ! $TARGET_FILE == $REPO_ROOT/* ]]; then
-            echo "Usage: open <file> [<line_number>].\nNOTE: Files must be in $REPO_ROOT. Relative paths preferred."
-            echo "Error: File is not within the repo root directory."
-            return 1
-        fi
     else
-        # Relative path
-        FULL_PATH="${REPO_ROOT}/${1}"
+        # Relative path: resolve relative to PWD
+        FULL_PATH="${PWD}/${1}"
+    fi
+    # make sure file is within REPO_ROOT
+    if [[ ! $(realpath $FULL_PATH) == $REPO_ROOT/* ]]; then
+        echo "Usage: open <file> [<line_number>].\nNOTE: Files must be in $REPO_ROOT. Relative paths preferred."
+        echo "Error: File is not within the repo root directory."
+        return 1
     fi
     if [ -f "$FULL_PATH" ]; then
         export CURRENT_FILE=$(realpath $FULL_PATH)

--- a/sweagent/agent/parsing.py
+++ b/sweagent/agent/parsing.py
@@ -135,6 +135,9 @@ class ThoughtActionParser(ParseFunction):
                 start = stack.pop()
                 # Check if it's not nested within another block
                 if not stack:
+                    if last_valid_block is not None:
+                        msg = "Multiple code blocks found in model response.  Your response must have at most one '\\nDISCUSSION\\n' string and at most one command."
+                        raise FormatError(msg)
                     last_valid_block = (start, match)
             elif match.group(1) is not None:  # Opening of a code block
                 stack.append(match)


### PR DESCRIPTION
the prompt already supports `working_dir` and the agent can `cd` around, so we might as well use `working_dir` to resolve relative paths.

also error out if the discussion/command text contains more than a single command.