### PR TITLE
[PRO-846] add otel instrumentation

### DIFF
--- a/.devcontainer/sample_keys.cfg
+++ b/.devcontainer/sample_keys.cfg
@@ -9,3 +9,5 @@
 # AZURE_OPENAI_API_VERSION: 'Azure OpenAI API Version Here if using Azure OpenAI Model'
 # OPENAI_API_BASE_URL: 'LM base URL here if using Local or alternative api Endpoint'
 # GROQ_API_KEY: 'Groq Models API Key'
+# HONEYCOMB_API_KEYH: 'Honeycomb API Key Here if sending otel traces to Honeycomb'
+# OTEL_EXPORTER_OTLP_ENDPOINT: 'OTLP Exporter Endpoint if sending otel traces to Honeycomb'

--- a/.devcontainer/sample_keys.cfg
+++ b/.devcontainer/sample_keys.cfg
@@ -9,5 +9,5 @@
 # AZURE_OPENAI_API_VERSION: 'Azure OpenAI API Version Here if using Azure OpenAI Model'
 # OPENAI_API_BASE_URL: 'LM base URL here if using Local or alternative api Endpoint'
 # GROQ_API_KEY: 'Groq Models API Key'
-# HONEYCOMB_API_KEYH: 'Honeycomb API Key Here if sending otel traces to Honeycomb'
+# HONEYCOMB_API_KEY: 'Honeycomb API Key Here if sending otel traces to Honeycomb'
 # OTEL_EXPORTER_OTLP_ENDPOINT: 'OTLP Exporter Endpoint if sending otel traces to Honeycomb'

--- a/docs/installation/keys.md
+++ b/docs/installation/keys.md
@@ -20,6 +20,9 @@ The following `keys.cfg` example shows you how the keys are named:
 # AZURE_OPENAI_DEPLOYMENT: 'Azure OpenAI Deployment Here if using Azure OpenAI Model'
 # AZURE_OPENAI_API_VERSION: 'Azure OpenAI API Version Here if using Azure OpenAI Model'
 # OPENAI_API_BASE_URL: 'LM base URL here if using Local or alternative api Endpoint'
+# GROQ_API_KEY: 'Groq Models API Key'
+# HONEYCOMB_API_KEYH: 'Honeycomb API Key Here if sending otel traces to Honeycomb'
+# OTEL_EXPORTER_OTLP_ENDPOINT: 'OTLP Exporter Endpoint if sending otel traces to Honeycomb'
 ```
 
 See the following links for tutorials on obtaining [Anthropic](https://docs.anthropic.com/claude/reference/getting-started-with-the-api), [OpenAI](https://platform.openai.com/docs/quickstart/step-2-set-up-your-api-key), and [Github](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) tokens.

--- a/docs/installation/keys.md
+++ b/docs/installation/keys.md
@@ -21,7 +21,7 @@ The following `keys.cfg` example shows you how the keys are named:
 # AZURE_OPENAI_API_VERSION: 'Azure OpenAI API Version Here if using Azure OpenAI Model'
 # OPENAI_API_BASE_URL: 'LM base URL here if using Local or alternative api Endpoint'
 # GROQ_API_KEY: 'Groq Models API Key'
-# HONEYCOMB_API_KEYH: 'Honeycomb API Key Here if sending otel traces to Honeycomb'
+# HONEYCOMB_API_KEY: 'Honeycomb API Key Here if sending otel traces to Honeycomb'
 # OTEL_EXPORTER_OTLP_ENDPOINT: 'OTLP Exporter Endpoint if sending otel traces to Honeycomb'
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,6 @@ google-auth-httplib2
 google-auth-oauthlib
 python-dotenv
 tqdm
+opentelemetry-api>=1.25.0
+opentelemetry-exporter-otlp-proto-http>=1.25.0
+opentelemetry-sdk>=1.25.0

--- a/sweagent/agent/agents.py
+++ b/sweagent/agent/agents.py
@@ -27,6 +27,7 @@ from sweagent.agent.parsing import FormatError, ParseFunction
 from sweagent.environment.swe_env import SWEEnv
 from sweagent.utils.config import convert_paths_to_abspath
 from sweagent.utils.log import get_logger
+from sweagent.utils.instrumentation import instrument
 
 logger = get_logger("agents")
 
@@ -774,6 +775,7 @@ class Agent:
         self.model.stats.replace(sub_agent.model.stats)
         return sub_agent_output
 
+    @instrument("Agent#run", params=["setup_args", "env", "observation", "traj_dir", "return_type", "init_model_stats"])
     def run(
         self,
         setup_args: dict[str, Any],

--- a/sweagent/environment/swe_env.py
+++ b/sweagent/environment/swe_env.py
@@ -44,6 +44,8 @@ from sweagent.environment.utils import (
 )
 from sweagent.utils.config import keys_config
 from sweagent.utils.log import default_logger, get_logger
+from sweagent.utils.instrumentation import instrument, current_span, set_current_span_error
+
 
 LONG_TIMEOUT = float(keys_config.get("SWE_AGENT_ENV_LONG_TIMEOUT", 500))
 AGENT_ACTION_TIMEOUT = float(keys_config.get("SWE_AGENT_ACTION_TIMEOUT", 25))
@@ -749,6 +751,7 @@ class SWEEnv(gym.Env):
         output = self._communicate(f"/bin/bash -n <<'EOF'\n{input}\nEOF\n")
         return output, self.returncode == 0
 
+    @instrument("SWEEnv#communicate", params=["input", "timeout_duration"])
     def communicate(self, input: str, timeout_duration: int | float = 25, *, set_last_action: bool = False) -> str:
         """
         Sends input to container and returns output
@@ -765,6 +768,7 @@ class SWEEnv(gym.Env):
             self.logger.log(logging.TRACE, "Input:\n%s", input)  # type: ignore
             output, valid = self._check_syntax(input)
             if not valid:
+                set_current_span_error(output)
                 return output  # shows syntax errors
             output = self._communicate(
                 input,
@@ -772,6 +776,10 @@ class SWEEnv(gym.Env):
             )
             self.logger.log(logging.TRACE, "Output:\n%s", output)  # type: ignore
             self.communicate_output = output
+            current_span().set_attributes({
+                "returncode": self.returncode,
+                "output": output,
+            })
             if set_last_action:
                 # Cannot merge this with last command, because of multiline command
                 # handling.
@@ -783,6 +791,10 @@ class SWEEnv(gym.Env):
             self.container.terminate()
             self.returncode = 0
             self.communicate_output = ""
+            current_span().set_attributes({
+                "returncode": 0,
+                "output": "",
+            })
             return ""
 
     def communicate_with_handling(self, input: str, error_msg: str, timeout_duration: int | float = 25) -> str:

--- a/sweagent/utils/instrumentation.py
+++ b/sweagent/utils/instrumentation.py
@@ -1,0 +1,127 @@
+import functools
+import inspect
+from typing import List
+from opentelemetry import trace
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource, Attributes
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace.export import (
+    BatchSpanProcessor,
+)
+
+from sweagent.utils.config import keys_config
+
+# re-export this from here so we don't have to litter the code with otel imports
+Tracer = trace.Tracer
+
+_tracer = None
+
+
+def tracer() -> Tracer:
+    global _tracer
+
+    if _tracer is None:
+        # warn about tracer being uninitialized but don't fail here - instead return a NoOpProvider tracer (tests seem to hit this.)
+        print("WARNING: tracer not initialized.  Returning NoOpProvider tracer.")
+        _tracer = trace.get_tracer_provider().get_tracer("replayio.ai_playground")
+
+    return _tracer
+
+
+def set_tracer(tracer: Tracer):
+    global _tracer
+    _tracer = tracer
+
+
+def current_span() -> trace.Span:
+    return trace.get_current_span()
+
+
+# Creates a tracer from the global tracer provider
+def initialize_tracer(attributes: Attributes | None = None):
+    service_resource = Resource.create(
+        {
+            SERVICE_NAME: "SWE-agent",
+        }
+    )
+
+    extra_resource = (
+        Resource.get_empty() if attributes is None else Resource.create(attributes)
+    )
+
+    exporter = None
+    api_key = keys_config.get("HONEYCOMB_API_KEY")
+    otlp_endpoint = keys_config.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if api_key is not None and otlp_endpoint is not None:
+        # TODO(toshok): this is for grpc, which I'd love to use, but doesn't seem to work?
+        # exporter = OTLPSpanExporter(
+        #     endpoint=keys_config.get("OTEL_EXPORTER_OTLP_ENDPOINT"),
+        #     headers=(("x-honeycomb-team", api_key)),
+        # )
+        exporter = OTLPSpanExporter(
+            endpoint=otlp_endpoint,
+            headers={
+                "x-honeycomb-team": api_key,
+            },
+        )
+
+    if exporter is None:
+        provider = trace.NoOpTracerProvider()
+    else:
+        provider = TracerProvider(resource=extra_resource.merge(service_resource))
+        processor = BatchSpanProcessor(exporter)
+        provider.add_span_processor(processor)
+
+    # Sets the global default tracer provider
+    trace.set_tracer_provider(provider)
+
+    set_tracer(trace.get_tracer("SWE-agent"))
+
+def instrument(
+    name: str, params: List[str] | None = None, attributes: Attributes | None = None
+):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            span_attributes = {}
+
+            if params:
+                sig = inspect.signature(func)
+                bound_args = sig.bind(*args, **kwargs)
+                bound_args.apply_defaults()
+
+                include_all_kwargs = "kwargs" in params
+                kwargs_to_include = [
+                    p.split(".")[1] for p in params if p.startswith("kwargs.")
+                ]
+
+                for param in params:
+                    if param == "kwargs" or param.startswith("kwargs."):
+                        # we'll handle these below
+                        continue
+                    elif param in bound_args.arguments:
+                        span_attributes[param] = bound_args.arguments[param]
+
+                # Handle kwargs
+                if include_all_kwargs or kwargs_to_include:
+                    for k, v in bound_args.arguments.get("kwargs", {}).items():
+                        if include_all_kwargs or k in kwargs_to_include:
+                            span_attributes[f"kwarg.{k}"] = v
+
+            if attributes:
+                span_attributes.update(attributes)
+
+            with tracer().start_as_current_span(name, attributes=span_attributes):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+__all__ = [
+    "current_span",
+    "initialize_tracer",
+    "instrument",
+    "tracer",
+]

--- a/sweagent/utils/instrumentation.py
+++ b/sweagent/utils/instrumentation.py
@@ -112,7 +112,15 @@ def instrument(
                 span_attributes.update(attributes)
 
             with tracer().start_as_current_span(name, attributes=span_attributes):
-                return func(*args, **kwargs)
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    current_span().set_status(
+                        trace.StatusCode.ERROR,
+                        description=str(e)
+                    )
+                    current_span().record_exception(e)
+                    raise
 
         return wrapper
 

--- a/sweagent/utils/instrumentation.py
+++ b/sweagent/utils/instrumentation.py
@@ -36,6 +36,13 @@ def set_tracer(tracer: Tracer):
 def current_span() -> trace.Span:
     return trace.get_current_span()
 
+def set_current_span_error(description: str):
+    current_span().set_status(
+        trace.Status(
+            trace.StatusCode.ERROR,
+            description=description,
+        )
+    )
 
 # Creates a tracer from the global tracer provider
 def initialize_tracer(attributes: Attributes | None = None):
@@ -115,10 +122,7 @@ def instrument(
                 try:
                     return func(*args, **kwargs)
                 except Exception as e:
-                    current_span().set_status(
-                        trace.StatusCode.ERROR,
-                        description=str(e)
-                    )
+                    set_current_span_error(str(e))
                     current_span().record_exception(e)
                     raise
 
@@ -131,5 +135,6 @@ __all__ = [
     "current_span",
     "initialize_tracer",
     "instrument",
+    "set_current_span_error",
     "tracer",
 ]


### PR DESCRIPTION
pretty bare-bones instrumentation for the time being, but it includes afaict all command execution (including `input`/`output`/`returncode` fields) and `AnthropicWithToolsThoughtsParser#__call__` spans with `action`/`model_response` fields):

<img width="1435" alt="image" src="https://github.com/user-attachments/assets/b513fa19-ba3c-463b-a213-2992ba5d3a3c">
