### PR TITLE
bump python to 3.10 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ name = "sweagent"
 dynamic = ["version", "dependencies"]
 description = "The official SWE-agent package - an open source Agent Computer Interface for running language models as software engineers."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 keywords = ["nlp", "agents", "code"]
 authors = [


### PR DESCRIPTION
I've been using `rye sync` to pull everything down which seemed to work until just recently, when I started getting type errors.

Type aliases using `|` were being misparsed as the bit-wise OR instead of union, for some reason.  e.g. something like `Type = str | int`.  They weren't being misparsed in function signatures, though 🤪 

I found one file with that problem that was missing `from __future__ import annotation` (required in 3.9 to add support for that syntax).  Adding that fixed that error, but the next whack-a-mole was in a file that already had that import.  Switching that example above `Type = typings.Union[str, int]` would fix it, but I didn't want to deal with all the additional likely changes.

3.10 supports the `|` syntax natively without the additional import.  I'm not sure why the version specifier there doesn't match 3.10 in the before version.  maybe >= only matches patch releases?