### PR TITLE
[PRO-812] manual input

### DIFF
--- a/config/_tdd_repro_prompt.md
+++ b/config/_tdd_repro_prompt.md
@@ -1,7 +1,9 @@
 ## Requirements
 
 * You are provided `tdd_*` tools to reproduce the issue with one or more golden tests and also check for regressions.
-* The output of the last reproduction is always provided to you.
 * Always start your investigations from the failing test.
 * When deciding to investigate some part of the code, EXPLAIN CLEARLY why you think that this is the next step to take.
 * Don't submit until the reproduction command proves your fix.
+
+## HOW TO BEGIN
+To start things off, run the 'tdd_repro' command to reproduce the issue.

--- a/config/commands/_tdd.sh
+++ b/config/commands/_tdd.sh
@@ -10,6 +10,12 @@ tdd_repro() {
     pushd $REPO_ROOT > /dev/null
     echo -e "Running tests to reproduce the bug (from $PWD):\n >$TEST_CMD_FAIL_TO_PASS\n"
     eval "$TEST_CMD_FAIL_TO_PASS"
+
+    # include the continuation file if it exists
+    if [ -f "$MANUAL_INPUT_CONTINUATION_FILE" ]; then
+        cat $MANUAL_INPUT_CONTINUATION_FILE
+        rm $MANUAL_INPUT_CONTINUATION_FILE
+    fi
     popd > /dev/null
 }
 

--- a/config/default_with_tools.yaml
+++ b/config/default_with_tools.yaml
@@ -28,9 +28,6 @@ instance_template: |-
   3. CWD is the directory of the repo you are supposed to edit. Only modify files inside this directory. Always provide absolute file paths, prefixed with $PWD.
   4. When editing files, it is easy to accidentally specify a wrong line number or to write code with incorrect indentation. Always check the code after you issue an edit to make sure that it reflects what you wanted to accomplish. If it didn't, issue another command to fix it.
 
-  # HOW TO BEGIN
-  To start things off, run the 'tdd_repro' command to reproduce the issue.
-
   (Open file: {open_file})
   (Current directory: {working_dir})
   bash-$

--- a/config/default_with_tools.yaml
+++ b/config/default_with_tools.yaml
@@ -14,7 +14,6 @@ instance_template: |-
   {issue}
   </ISSUE_DESCRIPTION>
 
-  {tdd_results}
   # INSTRUCTIONS
   * Solve this issue on your own. Your terminal session has started and you're in the repository's root directory. Edit files and run any checks or tests as needed.
   * YOU CAN ONLY MAKE ONE TOOL CALL (RUN A COMMAND) AT A TIME. You should always wait for feedback after every command.
@@ -29,6 +28,8 @@ instance_template: |-
   3. CWD is the directory of the repo you are supposed to edit. Only modify files inside this directory. Always provide absolute file paths, prefixed with $PWD.
   4. When editing files, it is easy to accidentally specify a wrong line number or to write code with incorrect indentation. Always check the code after you issue an edit to make sure that it reflects what you wanted to accomplish. If it didn't, issue another command to fix it.
 
+  # HOW TO BEGIN
+  To start things off, run the 'tdd_repro' command to reproduce the issue.
 
   (Open file: {open_file})
   (Current directory: {working_dir})

--- a/run_instance.sh
+++ b/run_instance.sh
@@ -1,8 +1,24 @@
 set -euo pipefail
+
+case $# in
+  1)
+    MANUAL_INPUT_ARGS=""
+    ;;
+
+  3)
+    MANUAL_INPUT_ARGS="--manual_input_conversation_path $2 --manual_input_continuation_label $3"
+    ;;
+
+  *)
+    echo "Usage: $0 <instance_id> [<manual_input_conversation_path> <manual_input_continuation_label>]"
+    exit 1
+    ;;
+esac
+
 set -x
 
-# This runs the instance from the official SWE-agent demo video.
-# See: https://www.youtube.com/watch?v=CeMtJ4XObAM
+echo $MANUAL_INPUT_ARGS
+
 python3 run.py \
   --model_name "claude-sonnet-3.5" \
   --data_path "princeton-nlp/SWE-bench_Verified" \
@@ -12,5 +28,6 @@ python3 run.py \
   --instance_filter "$1" \
   --skip_existing False \
   --cache_task_images \
-  --tdd
+  --tdd \
+  $MANUAL_INPUT_ARGS
 

--- a/sweagent/agent/agents.py
+++ b/sweagent/agent/agents.py
@@ -332,16 +332,6 @@ class Agent:
             if "tdd" in entry:
                 entry["tdd"] = False
 
-    def _make_initial_tdd_result(self) -> str:
-        if self.env.tdd:
-            if "{tdd_results}" not in self.config.instance_template:
-                # {tdd_results} needs to be referenced in instance_template for this to work.
-                raise ValueError("{tdd_results} not found in instance_template:\n\n" + self.config.instance_template)
-            test_result = self.env.communicate("tdd_repro")
-            # logger.debug(f"[TDD] Initial Results:\n{test_result}")
-            return f"# ISSUE REPRODUCTION RESULTS<NOTE: These are the results of a test run of tests that reproduce the issue. Start your investigation here./>\n<ISSUE_REPRODUCTION>\n{test_result}\n</ISSUE_REPRODUCTION>\n\n"
-        return ""
-
     # ###########################################################################
     # setup and more
     # ###########################################################################
@@ -656,8 +646,6 @@ class Agent:
             templates = [self.config.instance_template]
             if self.config.strategy_template is not None:
                 templates.append(self.config.strategy_template)
-            # Get tdd_results, to be rendered into the initial_prompt template.
-            # state_vars["tdd_results"] = self._make_initial_tdd_result()
         elif observation is None or observation.strip() == "":
             # Show no output template if observation content was empty
             templates = [self.config.next_step_no_output_template]

--- a/sweagent/agent/manual_input.py
+++ b/sweagent/agent/manual_input.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+import os
+from typing import Tuple
+
+from sweagent.utils.log import get_logger
+from sweagent.agent.model_cache import json_serialize_file, json_deserialize_file, json_serialize_str, json_deserialize_str, hash_string
+
+ManualTDDInputEnvVar = "MANUAL_TDD_INPUT_DIRECTORY"
+
+logger = get_logger("manual_tdd_input")
+
+class ManualInput:
+    base_dir: str | None
+    instance_id: str | None
+    conversation_path: str | None
+    continuation_label: str | None
+
+    def __init__(self, conversation_path: str | None, continuation_label: str | None):
+        self.conversation_path = conversation_path
+        self.continuation_label = continuation_label
+        self.base_dir = None
+        if ManualTDDInputEnvVar in os.environ:
+            logger.warning("⚠ ManualInput is enabled")
+            self.base_dir = os.environ[ManualTDDInputEnvVar]
+
+    def enabled(self) -> bool:
+        return self.base_dir is not None
+    
+    def set_instance_id(self, instance_id: str) -> None:
+        self.instance_id = instance_id
+
+    def _get_conversation_dir(self) -> str:
+        if self.conversation_path is None:
+            return os.path.join(self.base_dir, self.instance_id)
+        return os.path.join(self.base_dir, self.instance_id, self.conversation_path)
+
+    def load_continuation_file(self) -> str | None:
+        if not self.enabled():
+            return None
+
+        try:
+            with open(os.path.join(self._get_conversation_dir(), f"{self.continuation_label}.md"), "r") as f:
+                return f.read()
+        except FileNotFoundError:
+            return None
+
+    def save_conversation(self, conversation: list[dict[str, str]], patch: str | None) -> None:
+        if not self.enabled():
+            return None
+
+        parent_dir = self._get_conversation_dir()
+
+        # if continuation_label is left off, we're storing the root conversation
+        if self.continuation_label is None:
+            self.continuation_label = "root"
+
+        content = json_serialize_str(conversation)
+        hash = hash_string(content)
+
+        new_subdir = os.path.join(parent_dir, f"{self.continuation_label}-{hash}")
+        os.makedirs(new_subdir, exist_ok=True)
+        
+        with open(os.path.join(new_subdir, "conversation.json"), "w") as f:
+            f.write(content)
+
+        if patch is not None:
+            with open(os.path.join(new_subdir, "patch.diff"), "w") as f:
+                f.write(patch)
+
+    def load_conversation(self) -> Tuple[list[dict[str, str]], str] | None:
+        if not self.enabled():
+            return None
+
+        dir = self._get_conversation_dir()
+        if not os.path.exists(dir):
+            return None
+        
+        conversation_file_path = os.path.join(dir, "conversation.json")
+        if not os.path.exists(conversation_file_path):
+            return None
+        
+        with open(conversation_file_path, "r") as f:
+            conversation = json_deserialize_str(f.read())
+
+        patch_file_path = os.path.join(dir, "patch.diff")
+
+        # a missing patch isn't an error (will happen with the first tdd_repro call)
+        if os.path.exists(patch_file_path):
+            with open(patch_file_path, "r") as f:
+                patch = f.read()
+        else:
+            patch = None
+
+        return conversation, patch

--- a/sweagent/agent/manual_input.py
+++ b/sweagent/agent/manual_input.py
@@ -63,9 +63,12 @@ class ManualInput:
         with open(os.path.join(new_subdir, "conversation.json"), "w") as f:
             f.write(content)
 
-        if patch is not None:
+        if patch is not None and patch.strip() != "":
             with open(os.path.join(new_subdir, "patch.diff"), "w") as f:
                 f.write(patch)
+
+        subdir_to_print = new_subdir[len(self.base_dir):]
+        logger.info(f"Conversation saved to ${ManualTDDInputEnvVar}%s", subdir_to_print)
 
     def load_conversation(self) -> Tuple[list[dict[str, str]], str] | None:
         if not self.enabled():
@@ -90,5 +93,8 @@ class ManualInput:
                 patch = f.read()
         else:
             patch = None
+
+        dir_to_print = dir[len(self.base_dir):]
+        logger.info("Conversation loaded from ${ManualTDDInputEnvVar}%s", dir_to_print)
 
         return conversation, patch

--- a/sweagent/agent/model_cache.py
+++ b/sweagent/agent/model_cache.py
@@ -146,7 +146,7 @@ class ModelCache:
 
     def _get_file(self, history: list[dict[str, str]]) -> str:
         hash_input = json_serialize_str(history)
-        print(f"HASH_INPUT\n{hash_input}\nEND_OF_HASH_INPUT")
+        # print(f"HASH_INPUT\n{hash_input}\nEND_OF_HASH_INPUT")
         hash = hash_string(hash_input)
         return f"{self.directory}/model-query-{hash}.json"
 

--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -55,7 +55,7 @@ def get_last_valid_tool_use_block(model_result: ModelQueryResult | None, history
                 tool_use = last_assistant_block
     return tool_use
 
-def make_user_reply_content(action_result: str, model_result: ModelQueryResult | None, history: list[dict[str, any]], is_error: bool):
+def make_user_reply_content(action_result: str, model_result: ModelQueryResult | None, history: list[dict[str, any]], is_error: bool, tool_extra_content: str | None):
     """
     Create a tool_result block from the action_result, model_result, and history.
     action_result: The return value of the action from the environment.
@@ -65,10 +65,13 @@ def make_user_reply_content(action_result: str, model_result: ModelQueryResult |
     tool_use = get_last_valid_tool_use_block(model_result, history)
     if tool_use:
         # This is a reply to a tool_use:
+        if tool_use.name == "tdd_repro" and tool_extra_content is not None:
+            action_result += f"\n\n{tool_extra_content}"
+
         result = {
             "type": "tool_result",
             "tool_use_id": tool_use.id,
-            "content": action_result
+            "content": action_result,
         }
         if is_error:
             result["is_error"] = True

--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -55,7 +55,7 @@ def get_last_valid_tool_use_block(model_result: ModelQueryResult | None, history
                 tool_use = last_assistant_block
     return tool_use
 
-def make_user_reply_content(action_result: str, model_result: ModelQueryResult | None, history: list[dict[str, any]], is_error: bool, tool_extra_content: str | None):
+def make_user_reply_content(action_result: str, model_result: ModelQueryResult | None, history: list[dict[str, any]], is_error: bool):
     """
     Create a tool_result block from the action_result, model_result, and history.
     action_result: The return value of the action from the environment.
@@ -65,9 +65,6 @@ def make_user_reply_content(action_result: str, model_result: ModelQueryResult |
     tool_use = get_last_valid_tool_use_block(model_result, history)
     if tool_use:
         # This is a reply to a tool_use:
-        if tool_use.name == "tdd_repro" and tool_extra_content is not None:
-            action_result += f"\n\n{tool_extra_content}"
-
         result = {
             "type": "tool_result",
             "tool_use_id": tool_use.id,

--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -33,6 +33,11 @@ logger = get_logger("api_models")
 _MAX_RETRIES = keys_config.get("SWE_AGENT_MODEL_MAX_RETRIES", 0)
 
 
+def make_model_query_result(content: str | list[ContentBlock]) -> ModelQueryResult:
+    if isinstance(content, str):
+        return content
+    return AnthropicModelResult(blocks=content)
+
 def make_assistant_content(output: ModelQueryResult):
     if isinstance(output, str):
         return output

--- a/sweagent/environment/swe_env.py
+++ b/sweagent/environment/swe_env.py
@@ -466,6 +466,18 @@ class SWEEnv(gym.Env):
         )
         self.logger.debug(f"[TDD] Applied test patch - output:\n{res}")
 
+    def _apply_patch(self, patch: str) -> None:
+        """
+        Apply patch to source in repo
+        """
+        patch_path = "/root/model.patch"
+        self.copy_string_to_container_file(patch, patch_path)
+        self.communicate_with_handling(
+            f"cd /{self._repo_name} && cat {patch_path} && git apply -v {patch_path} && rm {patch_path}",
+            error_msg="Failed to apply patch",
+        )
+        self.logger.debug(f"[TDD] Applied previous changes - output:\n{res}")
+
     def step(self, action: str) -> tuple[str | None, int, bool, dict]:
         """
         Runs an action proposed by the agent in the environment and returns the corresponding output.

--- a/sweagent/environment/swe_env.py
+++ b/sweagent/environment/swe_env.py
@@ -466,14 +466,14 @@ class SWEEnv(gym.Env):
         )
         self.logger.debug(f"[TDD] Applied test patch - output:\n{res}")
 
-    def _apply_patch(self, patch: str) -> None:
+    def apply_conversation_patch(self, patch: str) -> None:
         """
         Apply patch to source in repo
         """
-        patch_path = "/root/model.patch"
+        patch_path = "/root/conversation.patch"
         self.copy_string_to_container_file(patch, patch_path)
-        self.communicate_with_handling(
-            f"cd /{self._repo_name} && cat {patch_path} && git apply -v {patch_path} && rm {patch_path}",
+        res = self.communicate_with_handling(
+            f"cd /{self._repo_name} && git apply -v {patch_path} && rm {patch_path}",
             error_msg="Failed to apply patch",
         )
         self.logger.debug(f"[TDD] Applied previous changes - output:\n{res}")


### PR DESCRIPTION
oops, ignore the branch name.

enabled by setting `MANUAL_TDD_INPUT_DIRECTORY` to the base storage dir.

Removes the tdd result from the initial instructions and replaces it with:

```
         # HOW TO BEGIN
         To start things off, run the 'tdd_repro' command to reproduce the issue.
```

That way the flow is substantially easier to reason about (and the directory structure makes quite a bit more sense), as only `tdd_repro` usage needs to be considered.

when you run the `run-instance.sh` script you can now run it in two ways:

## Starting a new conversation tree
`./run_instance.sh django__django-12419`

This will run the instance with the id `django__django-12419` and will create the directory `$BASE/django__django-12419/root-$conversation_hash` where `$conversation_hash` is a hash of the conversation.json file contained within it.

This will result in the following directory structure:

```
$BASE/
    django__django-12419/
        root-$root_hash/
            conversation.json
            patch.diff
```

## Testing new manual input (adding a new branch to the conversation)

First, create a `.md` file inside a conversation dir (sibling to the `conversation.json` file)

Then

`./run_instance.sh django__django-12419 $CONVERSATION_PATH $CONTINUATION_LABEL`

This will compute the directory `$BASE/django__django-12419/$CONVERSATION_PATH`, then load the following files from that directory:
1. `conversation.json`
2. `patch.diff`
3. `$CONTINUATION_LABEL.md`

The environment will be initialized with the normal repo contents + the patch applied, and the model will be initialized with the contents of conversation.json.  This conversation always ends with a tdd_repro tool_use.  The agent then acts as if the model has responded with this tdd_repro tool_use, runs the tool, and augments the tool response with the contents of the file `$CONTINUATION_LABEL.md`.  Execution proceeds normally until the _next_ `tdd_repro` tool use, at which point the conversation and new patch will be saved to the subdir `$CONTINUATION_LABEL-$conversation_hash/` (again where conversation_hash is a hash of the conversation.json file contained within that subdir).

As an example, the command line:

```
$ ./run_instance django__django-12419 root-$root_hash/my_first_label-$my_first_label_hash my_second_label
```

When run in a directory structure like this:

```
$BASE/
    django__django-12419/
        root-$root_hash/
            conversation.json
            my_first_label.md
            patch.diff

            my_first_label-$my_first_label_hash/
                conversation.json
                my_second_label.md
                patch.diff
```

will result in a directory structure like this:

```
$BASE/
    django__django-12419/
        root-$root_hash/
            conversation.json
            my_first_label.md
            patch.diff

            my_first_label-$my_first_label_hash/
                conversation.json
                my_second_label.md
                patch.diff

                my_second_label-$my_second_label_hash/   # this directory and contents will be created.
                    conversation.json
                    patch.diff
```
